### PR TITLE
fixed 'PSAvoidTrailingWhitespace"

### DIFF
--- a/mastermind.ps1
+++ b/mastermind.ps1
@@ -17,7 +17,7 @@ $correct = @('red', 'red', 'red', 'red')
 $counter = 10
 
 # Write initial text
-Write-Host "Available colors are: blue, green, red, yellow, orange, black"
+Write-Output "Available colors are: blue, green, red, yellow, orange, black"
 
    #
 DO # main loop
@@ -82,7 +82,7 @@ if ($args.length -eq 4) {
         Write-Host "You are the MASTERMIND!!!!"
 
         # exit all upon success
-        exit 
+        exit
     } else {
 
         # sort return list with red pins at beginning


### PR DESCRIPTION
PSScryptAnalyzer fix on line 85:
PSAvoidTrailingWhitespace Information   85PSAvoidTrailingWhitespace Information   85 Line has trailing whitespace

and on line 20:
PSAvoidUsingWriteHost  Warning   20 File 'mastermind.ps1' uses Write-Host. Avoid using Write-Host because it might not work in all

Additional Write-Host changes caused formatting problems so I stopped with the updates above.